### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bld/
 
 # Roslyn cache directories
 *.ide/
+.vs/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(bwheadless inject.cpp sc_hook.cpp main.cpp)


### PR DESCRIPTION
It's not that this is so much practically neded, but it is much better have CMake for building project, so you could build not only with VS, or control which version of CL to use without changing .vcproj